### PR TITLE
make CONTAINER_RUNTIME optional

### DIFF
--- a/aws.sh
+++ b/aws.sh
@@ -12,6 +12,10 @@ AWS_DEFAULT_REGION=$AWS_REGION
 
 # We need awscli to talk to AWS.
 if ! hash aws; then
+    if [ -z "$CONTAINER_RUNTIME" ]; then
+        echo 'no awscli, nor container runtime available, cannot proceed'
+        exit 2
+    fi
     echo "Using 'awscli' from a container"
     sudo ${CONTAINER_RUNTIME} pull ${CONTAINER_IMAGE_CLOUD_TOOLS}
 

--- a/gcp.sh
+++ b/gcp.sh
@@ -11,6 +11,10 @@ greenprint "starting gcp cleanup"
 
 # We need Google Gloud SDK to comunicate with gcp
 if ! hash gcloud; then
+    if [ -z "$CONTAINER_RUNTIME" ]; then
+        echo 'no gcloud cli, nor container runtime available, cannot proceed'
+        exit 2
+    fi
     echo "Using 'gcloud' from a container"
     sudo ${CONTAINER_RUNTIME} pull ${CONTAINER_IMAGE_CLOUD_TOOLS}
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -44,9 +44,6 @@ if [ -z "$COMMON_INCLUDED" ]; then
         CONTAINER_RUNTIME=podman
     elif which docker 2>/dev/null >&2; then
         CONTAINER_RUNTIME=docker
-    else
-        echo No container runtime found, install podman or docker.
-        exit 2
     fi
 
     CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest"


### PR DESCRIPTION
Running separate modules inside a container with all cloud-tools preinstalled is a very nice way of running cloud-cleaner in CI systems.

This commit therefore removes the check for a container runtime. The container runtime is now only required if the host misses the required cloud tool.

@jabia99 The github actions PoC doesn't work, but this PR should fix it. However, the scheduled cloud cleaner in gitlab survived! :) https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/3645894329