### PR TITLE
Improvements to cloud-image-val

### DIFF
--- a/.github/workflows/run_cloudx.yml
+++ b/.github/workflows/run_cloudx.yml
@@ -14,8 +14,8 @@ jobs:
 
     env:
       AWS_REGION: us-east-1
-      V2_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_CLOUDX }}
-      V2_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_CLOUDX }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_CLOUDX }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_CLOUDX }}
       #AWS_BUCKET: ${{ secrets.AWS_BUCKET_CLOUDX }} Cloudx doesn't store objects for now
 
     steps:
@@ -35,8 +35,8 @@ jobs:
       image: quay.io/osbuild/cloud-tools:latest
 
     env:
-      V2_AZURE_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID_CLOUDX }}"
-      V2_AZURE_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET_CLOUDX }}"
+      AZURE_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID_CLOUDX }}"
+      AZURE_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET_CLOUDX }}"
       AZURE_TENANT_ID: "${{ secrets.AZURE_TENANT_ID_CLOUDX }}"
 
     steps:

--- a/.github/workflows/run_ib.yml
+++ b/.github/workflows/run_ib.yml
@@ -72,22 +72,11 @@ jobs:
           ./gcp.sh
 
   ib-vmware:
+    # always skip b/c GOVMOMI_URL_IB is not reachable outside VPN, see
+    # https://gitlab.cee.redhat.com/osbuild/vcenter-cleaner
+    if: ${{ ! always() }}
     name: Image Builder vmware account
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/osbuild/cloud-tools:latest
-
-    env:
-      GOVMOMI_USERNAME: ${{ secrets.GOVMOMI_USERNAME_IB }}
-      GOVMOMI_PASSWORD: ${{ secrets.GOVMOMI_PASSWORD_IB }}
-      GOVMOMI_URL: ${{ secrets.GOVMOMI_URL_IB }}
-
     steps:
-      - name: Install dependencies
-        run: dnf install -y jq
-
-      - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Run the cleaning script
-        run: ./vmware.sh
+      - name: This workflow is internal only
+        run: echo

--- a/aws.sh
+++ b/aws.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # include the common library
 source $(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/lib/common.sh
 

--- a/aws.sh
+++ b/aws.sh
@@ -161,7 +161,7 @@ done
 # Remove old enough objects that don't have tag persist=true
 echo -e "----------------\nCleaning objects\n----------------"
 
-if [ -z "$AWS_BUCKET" ]; then
+if [ -z "${AWS_BUCKET:-}" ]; then
         echo '$AWS_BUCKET is empty, no obejct cleaning will be done'
         exit 0
 fi

--- a/azure.sh
+++ b/azure.sh
@@ -26,7 +26,7 @@ gpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.re
     az version
 fi
 
-az login --service-principal --username "${AZURE_CLIENT_ID}" --password "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}"
+az login --service-principal --username "${AZURE_CLIENT_ID:-}" --password "${AZURE_CLIENT_SECRET:-}" --tenant "${AZURE_TENANT_ID:-}"
 
 #---------------------------------------------------------------
 

--- a/azure.sh
+++ b/azure.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # include the common library
 source $(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/lib/common.sh
 

--- a/gcp.sh
+++ b/gcp.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # include the common library
 source $(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/lib/common.sh
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,5 +1,5 @@
 # c-inspired include guard to ensure these bits are sourced only once
-if [ -z "$COMMON_INCLUDED" ]; then
+if [ -z "${COMMON_INCLUDED:-}" ]; then
     COMMON_INCLUDED=YES
 
     # Colorful output.

--- a/vmware.sh
+++ b/vmware.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # include the common library
 source $(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/lib/common.sh
 


### PR DESCRIPTION
Notes:

CloudX Azure login is failing, job reported PASS:
https://github.com/osbuild/cloud-cleaner/actions/runs/5344222950/jobs/9688345341

CloudX AWS job says `Unable to locate credentials. You can configure credentials by running "aws configure"`, reports PASS:
https://github.com/osbuild/cloud-cleaner/actions/runs/5344222950/jobs/9688345169

Image Builder AWS job says `An error occurred (AuthFailure) when calling the DescribeRegions operation: AWS was not able to validate the provided access credentials`, reports PASS:
https://github.com/osbuild/cloud-cleaner/actions/runs/5344222063/jobs/9688343730

Image Builder vmware job says `/tmp/govc: Post "https://***/rest/com/vmware/cis/session": dial tcp: lookup *** on 127.0.0.11:53: no such host`, reports PASS:
https://github.com/osbuild/cloud-cleaner/actions/runs/5344222063/jobs/9688343356