### PR TITLE
Fixed retrieval of AWS regions.

### DIFF
--- a/.github/workflows/run_cloudx.yml
+++ b/.github/workflows/run_cloudx.yml
@@ -17,6 +17,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_CLOUDX }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_CLOUDX }}
       #AWS_BUCKET: ${{ secrets.AWS_BUCKET_CLOUDX }} Cloudx doesn't store objects for now
+      OLD_LINE: 'opt-in-not-required'
+      NEW_LINE: 'not-opted-in'
 
     steps:
       - name: Install dependencies
@@ -24,6 +26,10 @@ jobs:
 
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Modify aws.sh
+        run: |
+          sed -i "s|${OLD_LINE}|${NEW_LINE}|" aws.sh
 
       - name: Run the cleaning script
         run: ./aws.sh

--- a/aws.sh
+++ b/aws.sh
@@ -34,7 +34,7 @@ fi
 $AWS_CMD_NO_REGION --version
 
 AWS_CMD="${AWS_CMD_NO_REGION} --region ${AWS_REGION}"
-REGIONS=$(${AWS_CMD} ec2 describe-regions | jq -rc '.Regions[] | select(.OptInStatus == "opt-in-not-required") | .RegionName')
+REGIONS=$(${AWS_CMD} ec2 describe-regions | jq -rc '.Regions[] | select(.OptInStatus != "not-opted-in") | .RegionName')
 
 # We use resources in more than one region
 for region in ${REGIONS}; do

--- a/aws.sh
+++ b/aws.sh
@@ -34,7 +34,7 @@ fi
 $AWS_CMD_NO_REGION --version
 
 AWS_CMD="${AWS_CMD_NO_REGION} --region ${AWS_REGION}"
-REGIONS=$(${AWS_CMD} ec2 describe-regions | jq -rc '.Regions[] | select(.OptInStatus != "not-opted-in") | .RegionName')
+REGIONS=$(${AWS_CMD} ec2 describe-regions | jq -rc '.Regions[] | select(.OptInStatus == "opt-in-not-required") | .RegionName')
 
 # We use resources in more than one region
 for region in ${REGIONS}; do


### PR DESCRIPTION
We recently found an issue in CloudX team, we had hundreds of AMIs running and not cleaned up properly by cloud-cleaner.

After debugging, we found out that the regions affected were the ones filtered out by the current implementation of this script, which gathers only the regions enabled by default.

By using the OptInStatus != "not-opted-in" filter, we solve this issue and we gather all the regions actually enabled in the Account, despite they were enabled by default or opted in later on.