### PR TITLE
Fix: run_cloudx.yml

### DIFF
--- a/.github/workflows/run_cloudx.yml
+++ b/.github/workflows/run_cloudx.yml
@@ -17,8 +17,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_CLOUDX }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_CLOUDX }}
       #AWS_BUCKET: ${{ secrets.AWS_BUCKET_CLOUDX }} Cloudx doesn't store objects for now
-      OLD_LINE: '== "opt-in-not-required"'
-      NEW_LINE: '!= "not-opted-in"'
 
     steps:
       - name: Install dependencies
@@ -26,10 +24,6 @@ jobs:
 
       - name: Check out the repo
         uses: actions/checkout@v3
-
-      - name: Modify aws.sh
-        run: |
-          sed -i "s|${OLD_LINE}|${NEW_LINE}|" aws.sh
 
       - name: Run the cleaning script
         run: ./aws.sh

--- a/.github/workflows/run_cloudx.yml
+++ b/.github/workflows/run_cloudx.yml
@@ -17,8 +17,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_CLOUDX }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_CLOUDX }}
       #AWS_BUCKET: ${{ secrets.AWS_BUCKET_CLOUDX }} Cloudx doesn't store objects for now
-      OLD_LINE: 'opt-in-not-required'
-      NEW_LINE: 'not-opted-in'
+      OLD_LINE: '== "opt-in-not-required"'
+      NEW_LINE: '!= "not-opted-in"'
 
     steps:
       - name: Install dependencies

--- a/aws.sh
+++ b/aws.sh
@@ -34,7 +34,7 @@ fi
 $AWS_CMD_NO_REGION --version
 
 AWS_CMD="${AWS_CMD_NO_REGION} --region ${AWS_REGION}"
-REGIONS=$(${AWS_CMD} ec2 describe-regions | jq -rc '.Regions[] | select(.OptInStatus == "opt-in-not-required") | .RegionName')
+REGIONS=$(${AWS_CMD} ec2 describe-regions | jq -rc '.Regions[] | select(.OptInStatus != "not-opted-in") | .RegionName')
 
 # We use resources in more than one region
 for region in ${REGIONS}; do


### PR DESCRIPTION
The modification step that enables the CloudX specific requirement for opt in regions was missing the correct logical operator. The result was an empty list of regions and thus skipped the cleanup stage.
See [action log output](https://github.com/osbuild/cloud-cleaner/actions/runs/8843420731/job/24283638955).

Reference: [Previous PR](https://github.com/osbuild/cloud-cleaner/commit/98df7b6db78684be756535ce9024f7637c117f49) that enabled the opt-in regions.